### PR TITLE
Fix Claude workflow scope for pushing workflow files

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.BOT_TOKEN }}
           allowed_bots: "claude[bot]"
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Adds `github_token: ${{ secrets.BOT_TOKEN }}` to claude-code-action so Claude can push .github/workflows/ files. The default App token lacks `workflow` scope which blocks issues #8 and #9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->